### PR TITLE
Fix incorrect runs being placed on runners

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -29,4 +29,4 @@ plugins:
     out: ui/app/src/api
     opt:
       - paths=source_relative
-
+    strategy: all

--- a/db/querier.go
+++ b/db/querier.go
@@ -28,11 +28,11 @@ type Querier interface {
 	IssueAccessToken(ctx context.Context, db DBTX, arg IssueAccessTokenParams) (IssueAccessTokenRow, error)
 	// TODO re: ::text[] https://github.com/kyleconroy/sqlc/issues/1256
 	ListAccessTokens(ctx context.Context, db DBTX, arg ListAccessTokensParams) ([]ListAccessTokensRow, error)
+	ListPendingRuns(ctx context.Context, db DBTX) ([]Run, error)
 	ListRunners(ctx context.Context, db DBTX) ([]Runner, error)
 	ListRuns(ctx context.Context, db DBTX) ([]Run, error)
 	ListTestSuites(ctx context.Context, db DBTX, labels pgtype.JSONB) ([]TestSuite, error)
 	ListTests(ctx context.Context, db DBTX) ([]Test, error)
-	ListTestsIDsMatchingLabelKeys(ctx context.Context, db DBTX, arg ListTestsIDsMatchingLabelKeysParams) ([]ListTestsIDsMatchingLabelKeysRow, error)
 	ListTestsToSchedule(ctx context.Context, db DBTX) ([]Test, error)
 	QueryRunners(ctx context.Context, db DBTX, arg QueryRunnersParams) ([]Runner, error)
 	QueryRuns(ctx context.Context, db DBTX, arg QueryRunsParams) ([]Run, error)

--- a/db/queries/tests.sql
+++ b/db/queries/tests.sql
@@ -20,13 +20,6 @@ SELECT *
 FROM tests
 ORDER BY tests.name ASC;
 
--- name: ListTestsIDsMatchingLabelKeys :many
-SELECT tests.id, tests.labels
-FROM tests
-WHERE
-  tests.labels ?& COALESCE(sqlc.arg('include_label_keys')::varchar[], '{}') AND
-  NOT tests.labels ?| COALESCE(sqlc.arg('filter_label_keys')::varchar[], '{}')::varchar[];
-
 -- name: UpdateTest :exec
 UPDATE tests
 SET

--- a/db/tests.sql.go
+++ b/db/tests.sql.go
@@ -72,44 +72,6 @@ func (q *Queries) ListTests(ctx context.Context, db DBTX) ([]Test, error) {
 	return items, nil
 }
 
-const listTestsIDsMatchingLabelKeys = `-- name: ListTestsIDsMatchingLabelKeys :many
-SELECT tests.id, tests.labels
-FROM tests
-WHERE
-  tests.labels ?& COALESCE($1::varchar[], '{}') AND
-  NOT tests.labels ?| COALESCE($2::varchar[], '{}')::varchar[]
-`
-
-type ListTestsIDsMatchingLabelKeysParams struct {
-	IncludeLabelKeys []string
-	FilterLabelKeys  []string
-}
-
-type ListTestsIDsMatchingLabelKeysRow struct {
-	ID     uuid.UUID
-	Labels pgtype.JSONB
-}
-
-func (q *Queries) ListTestsIDsMatchingLabelKeys(ctx context.Context, db DBTX, arg ListTestsIDsMatchingLabelKeysParams) ([]ListTestsIDsMatchingLabelKeysRow, error) {
-	rows, err := db.Query(ctx, listTestsIDsMatchingLabelKeys, arg.IncludeLabelKeys, arg.FilterLabelKeys)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListTestsIDsMatchingLabelKeysRow
-	for rows.Next() {
-		var i ListTestsIDsMatchingLabelKeysRow
-		if err := rows.Scan(&i.ID, &i.Labels); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listTestsToSchedule = `-- name: ListTestsToSchedule :many
 SELECT tests.id, tests.name, tests.run_config, tests.labels, tests.matrix, tests.cron_schedule, tests.next_run_at, tests.registered_at, tests.updated_at
 FROM tests

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: tstr-grpc:9000
             - name: RUN_INSECURE
               value: "true"
+            - name: RUN_ACCEPT_LABEL_SELECTORS
+              value: "region=nyc"
             - name: RUN_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/scheduler/matrix.go
+++ b/scheduler/matrix.go
@@ -56,7 +56,11 @@ func generateMatrixLabelSet(b map[string]string, ml map[string][]string) []map[s
 		}
 
 		for {
-			labels := make(map[string]string)
+			labels := copyLabels(b)
+			if labels == nil {
+				labels = make(map[string]string)
+			}
+
 			for _, rk := range keys {
 				labels[rk] = ml[rk][kIdx[rk]]
 			}
@@ -80,4 +84,16 @@ func generateMatrixLabelSet(b map[string]string, ml map[string][]string) []map[s
 	}
 
 	return labelSets
+}
+
+func copyLabels(l map[string]string) map[string]string {
+	if l == nil {
+		return nil
+	}
+
+	c := make(map[string]string)
+	for k, v := range l {
+		c[k] = v
+	}
+	return c
 }

--- a/scheduler/matrix_test.go
+++ b/scheduler/matrix_test.go
@@ -38,11 +38,11 @@ func Test_generateLabelSet(t *testing.T) {
 		},
 		{
 			name:         "matrix overwrite base",
-			baseLabels:   map[string]string{"key": "value"},
+			baseLabels:   map[string]string{"key": "value", "other": "label"},
 			matrixLabels: map[string][]string{"key": {"value_1", "value_2"}},
 			labelSet: []map[string]string{
-				{"key": "value_1"},
-				{"key": "value_2"},
+				{"key": "value_1", "other": "label"},
+				{"key": "value_2", "other": "label"},
 			},
 		},
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -172,15 +172,3 @@ func (s *Scheduler) Stop(ctx context.Context) {
 		}
 	}
 }
-
-func copyLabels(l map[string]string) map[string]string {
-	if l == nil {
-		return nil
-	}
-
-	c := make(map[string]string)
-	for k, v := range l {
-		c[k] = v
-	}
-	return c
-}


### PR DESCRIPTION
This primarily fixes run placement (the logic/query were just incorrect to begin with), but also addresses a few small issues I found while debugging:
- duplication warning generate ts pbs
- base labels not being added to test matrix runs