### PR TITLE
Support reloading local dev with dev/up

### DIFF
--- a/dev/common.sh
+++ b/dev/common.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export dev_state_path=".dev"
+export dev_overmind_sock="$dev_state_path/overmind.sock"

--- a/dev/down
+++ b/dev/down
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-overmind quit
+# shellcheck source=dev/common.sh
+source dev/common.sh
+# shellcheck source=scripts/common.sh
+source scripts/common.sh
+
+run "Tearing down local dev..." overmind quit --socket "$dev_overmind_sock"

--- a/dev/up
+++ b/dev/up
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
-mkdir -p .dev
-overmind start --auto-restart api,runner,ui,db --daemonize
-dbmate --wait up
+# shellcheck source=dev/common.sh
+source dev/common.sh
+# shellcheck source=scripts/common.sh
+source scripts/common.sh
+
+mkdir -p "$dev_state_path"
+
+if [ ! -S "$dev_overmind_sock" ]; then
+  run "Bringing up local dev..." overmind start \
+    --title tstr \
+    --auto-restart api,runner,ui,ui-vite,db \
+    --socket "$dev_overmind_sock" \
+    --daemonize
+else
+  run "Reloading local dev..." overmind restart --socket "$dev_overmind_sock"
+fi
+
+run "Running DB migrations" dbmate --wait up

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+export scripts_path="${BASH_SOURCE%/*}"
+
+# run starts running a named command making sure to format stdout and stderr of
+# the command with descriptive line prefixes.
+# arguments: msg, command, [arg1 arg2 ...]
+function run() {
+  echo "┬─> $1"
+  "${@:2}" > >(prepend "│o: ") 2> >(prepend "│e: " >&2)
+  echo "└─> Done"
+}
+
+# prepend reads line on stdin and prepends a prefix to each line.
+# arguments: prefix
+function prepend() {
+    while read -r line; do
+        if [[ -n "$line" ]]; then
+            echo "$1$line"
+        fi
+    done
+}

--- a/scripts/deploy-runners.sh
+++ b/scripts/deploy-runners.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -4,24 +4,8 @@ set -eo pipefail
 
 scripts_path="${BASH_SOURCE%/*}"
 
-# run starts running a named command making sure to format stdout and stderr of
-# the command with descriptive line prefixes.
-# arguments: msg, command, [arg1 arg2 ...]
-function run() {
-  echo "┬─> $1"
-  "${@:2}" > >(prepend "│o: ") 2> >(prepend "│e: " >&2)
-  echo "└─> Done"
-}
-
-# prepend reads line on stdin and prepends a prefix to each line.
-# arguments: prefix
-function prepend() {
-    while read -r line; do
-        if [[ -n "$line" ]]; then
-            echo "$1$line"
-        fi
-    done
-}
+# shellcheck source=scripts/common.sh
+source "$scripts_path/common.sh"
 
 options=$(getopt -l "gotags:" -o "t:" -a -- "$@")
 eval set -- "$options"
@@ -40,8 +24,6 @@ do
   esac
   shift
 done
-
-
 
 run "Generating protobufs..." "$scripts_path/gen_pb.sh"
 run "Generating db implementation..." "$scripts_path/gen_db.sh"


### PR DESCRIPTION
Small quality of life improvement making it possible to use `dev/up` for both bringing up and reloading the local dev env.