### PR TITLE
Github Actions workflow improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         id: build
         run: |
           nix build .#image
-          echo "::set-output name=image_tag::$(nix eval --raw .#image.imageTag)"
+          echo "image_tage=$(nix eval --raw .#image.imageTag)" >> $GITHUB_OUTPUT
       - name: Upload built image
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,9 +16,6 @@ jobs:
     concurrency: ${{ inputs.environment }}
     environment: ${{ inputs.environment }}
     steps:
-      - run: |
-          echo ${{ secrets.PG_DSN }} | wc -c
-          echo ${{ secrets.UI_ACCESS_TOKEN }} | wc -c
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
       - uses: cachix/cachix-action@v10

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,11 +8,10 @@ jobs:
     secrets: inherit
   build:
     uses: ./.github/workflows/build.yaml
-    needs: [test]
     secrets: inherit
   deploy:
     uses: ./.github/workflows/deploy.yaml
-    needs: [build]
+    needs: [build, test]
     secrets: inherit
     with:
       environment: demo


### PR DESCRIPTION
- Update deprecated `set-output` to using `$GITHUB_OUTPUT`
- Allow build and test jobs to run in parallel ahead of deploy
- Cleanup debug steps in deploy workflow