### PR TITLE
Append namespace to outgoing context for remaining ctl sub-commands

### DIFF
--- a/cmd/tstr/ctl_run_cmd.go
+++ b/cmd/tstr/ctl_run_cmd.go
@@ -8,5 +8,7 @@ var ctlRunCmd = &cobra.Command{
 }
 
 func init() {
+	ctlTestCmd.PersistentFlags().StringVar(&ctlTestNamespace, "namespace", "", "The namespace to use.")
+	ctlTestCmd.MarkPersistentFlagRequired("namespace")
 	ctlCmd.AddCommand(ctlRunCmd)
 }

--- a/cmd/tstr/ctl_run_schedule_cmd.go
+++ b/cmd/tstr/ctl_run_schedule_cmd.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	controlv1 "github.com/nanzhong/tstr/api/control/v1"
+	"github.com/nanzhong/tstr/grpc/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -19,6 +21,7 @@ var ctlRunScheduleCmd = &cobra.Command{
 		defer cancel()
 
 		return withControlClient(ctx, viper.GetString("ctl.grpc-addr"), !viper.GetBool("ctl.insecure"), viper.GetString("ctl.access-token"), func(ctx context.Context, client controlv1.ControlServiceClient) error {
+			ctx = metadata.AppendToOutgoingContext(ctx, auth.MDKeyNamespace, ctlTestNamespace)
 			res, err := client.ScheduleRun(ctx, &controlv1.ScheduleRunRequest{
 				TestId: args[0],
 			})

--- a/cmd/tstr/ctl_test_delete_cmd.go
+++ b/cmd/tstr/ctl_test_delete_cmd.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	controlv1 "github.com/nanzhong/tstr/api/control/v1"
+	"github.com/nanzhong/tstr/grpc/auth"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -17,6 +19,7 @@ var ctlTestDeleteCmd = &cobra.Command{
 		return withCtlControlClient(context.Background(), func(ctx context.Context, client controlv1.ControlServiceClient) error {
 			fmt.Printf("Deleting registered test %s...\n", args[0])
 
+			ctx = metadata.AppendToOutgoingContext(ctx, auth.MDKeyNamespace, ctlTestNamespace)
 			res, err := client.DeleteTest(ctx, &controlv1.DeleteTestRequest{Id: args[0]})
 			if err != nil {
 				return err

--- a/cmd/tstr/ctl_test_get_cmd.go
+++ b/cmd/tstr/ctl_test_get_cmd.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	controlv1 "github.com/nanzhong/tstr/api/control/v1"
+	"github.com/nanzhong/tstr/grpc/auth"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -17,6 +19,7 @@ var ctlTestGetCmd = &cobra.Command{
 		return withCtlControlClient(context.Background(), func(ctx context.Context, client controlv1.ControlServiceClient) error {
 			fmt.Printf("Getting registered test %s...\n", args[0])
 
+			ctx = metadata.AppendToOutgoingContext(ctx, auth.MDKeyNamespace, ctlTestNamespace)
 			res, err := client.GetTest(ctx, &controlv1.GetTestRequest{Id: args[0]})
 			if err != nil {
 				return err

--- a/cmd/tstr/ctl_test_register_cmd.go
+++ b/cmd/tstr/ctl_test_register_cmd.go
@@ -126,6 +126,7 @@ var (
 			}
 
 			return withCtlControlClient(context.Background(), func(ctx context.Context, client controlv1.ControlServiceClient) error {
+				ctx = metadata.AppendToOutgoingContext(ctx, auth.MDKeyNamespace, ctlTestNamespace)
 				if test.Id == "" {
 					fmt.Printf("Registering new test: %s\n", test.Name)
 


### PR DESCRIPTION
@nanzhong 
This is fixing the functionality for remaining ctl subcommands. 
Tested locally and everything works as expected