### PR TITLE
Add test for simpler runs queries

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
 ;;; Directory Local Variables            -*- no-byte-compile: t -*-
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((magit-status-mode . ((magit-todos-exclude-globs . (".git/" "vendor/")))))
+((go-mode . ((eglot-workspace-configuration . (:gopls (:buildFlags ["-tags=integration,ui"])))))
+ (magit-status-mode . ((magit-todos-exclude-globs . (".git/" "vendor/")))))

--- a/db/queries/runs.sql
+++ b/db/queries/runs.sql
@@ -9,7 +9,8 @@ WHERE runs.id = sqlc.arg('id');
 SELECT runs.*
 FROM runs
 JOIN tests
-ON runs.test_id = tests.id AND tests.namespace = sqlc.arg('namespace');
+ON runs.test_id = tests.id AND tests.namespace = sqlc.arg('namespace')
+ORDER BY runs.scheduled_at ASC;
 
 -- name: ScheduleRun :one
 INSERT INTO runs (test_id, test_run_config, labels, test_matrix_id)
@@ -23,7 +24,8 @@ SELECT runs.*, tests.namespace
 FROM runs
 JOIN tests
 ON runs.test_id = tests.id
-WHERE runner_id IS NULL;
+WHERE runner_id IS NULL
+ORDER BY runs.scheduled_at ASC;
 
 -- name: AssignRun :one
 UPDATE runs
@@ -34,6 +36,7 @@ WHERE runs.id = (
   WHERE
     matching_runs.id = ANY (sqlc.arg('run_IDs')::uuid[]) AND
     matching_runs.runner_id IS NULL
+  ORDER BY matching_runs.scheduled_at ASC
   LIMIT 1
   FOR UPDATE SKIP LOCKED
 )
@@ -58,7 +61,7 @@ WHERE id = sqlc.arg('id');
 
 -- name: UpdateResultData :exec
 UPDATE runs
-SET result_data = result_data || sqlc.arg('result_data')::jsonb 
+SET result_data = result_data || sqlc.arg('result_data')::jsonb
 WHERE id = sqlc.arg('id');
 
 -- name: ResetOrphanedRuns :exec
@@ -86,7 +89,7 @@ FROM runs
 JOIN tests
 ON runs.test_id = tests.id AND tests.namespace = sqlc.arg('namespace')
 WHERE runs.test_id = sqlc.arg('test_id') AND runs.scheduled_at > sqlc.arg('scheduled_after')
-ORDER by runs.scheduled_at desc;
+ORDER by runs.scheduled_at DESC;
 
 -- name: RunSummariesForRunner :many
 SELECT runs.id, tests.namespace AS test_namespace, tests.id AS test_id, tests.name AS test_name, runs.test_run_config, runs.labels, runs.runner_id, runs.result, runs.scheduled_at, runs.started_at, runs.finished_at, runs.result_data
@@ -94,7 +97,7 @@ FROM runs
 JOIN tests
 ON runs.test_id = tests.id AND tests.namespace = sqlc.arg('namespace')
 WHERE runs.runner_id = sqlc.arg('runner_id') AND runs.scheduled_at > sqlc.arg('scheduled_after')
-ORDER by runs.scheduled_at desc;
+ORDER by runs.scheduled_at DESC;
 
 -- name: QueryRuns :many
 SELECT runs.*

--- a/db/runs.sql.go
+++ b/db/runs.sql.go
@@ -39,6 +39,7 @@ WHERE runs.id = (
   WHERE
     matching_runs.id = ANY ($2::uuid[]) AND
     matching_runs.runner_id IS NULL
+  ORDER BY matching_runs.scheduled_at ASC
   LIMIT 1
   FOR UPDATE SKIP LOCKED
 )
@@ -119,6 +120,7 @@ FROM runs
 JOIN tests
 ON runs.test_id = tests.id
 WHERE runner_id IS NULL
+ORDER BY runs.scheduled_at ASC
 `
 
 type ListPendingRunsRow struct {
@@ -176,6 +178,7 @@ SELECT runs.id, runs.test_id, runs.test_run_config, runs.test_matrix_id, runs.la
 FROM runs
 JOIN tests
 ON runs.test_id = tests.id AND tests.namespace = $1
+ORDER BY runs.scheduled_at ASC
 `
 
 func (q *Queries) ListRuns(ctx context.Context, db DBTX, namespace string) ([]Run, error) {
@@ -309,7 +312,7 @@ FROM runs
 JOIN tests
 ON runs.test_id = tests.id AND tests.namespace = $1
 WHERE runs.runner_id = $2 AND runs.scheduled_at > $3
-ORDER by runs.scheduled_at desc
+ORDER by runs.scheduled_at DESC
 `
 
 type RunSummariesForRunnerParams struct {
@@ -372,7 +375,7 @@ FROM runs
 JOIN tests
 ON runs.test_id = tests.id AND tests.namespace = $1
 WHERE runs.test_id = $2 AND runs.scheduled_at > $3
-ORDER by runs.scheduled_at desc
+ORDER by runs.scheduled_at DESC
 `
 
 type RunSummariesForTestParams struct {
@@ -657,7 +660,7 @@ func (q *Queries) TimeoutRuns(ctx context.Context, db DBTX, arg TimeoutRunsParam
 
 const updateResultData = `-- name: UpdateResultData :exec
 UPDATE runs
-SET result_data = result_data || $1::jsonb 
+SET result_data = result_data || $1::jsonb
 WHERE id = $2
 `
 

--- a/db/runs_test.go
+++ b/db/runs_test.go
@@ -1,0 +1,429 @@
+//go:build integration
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunsQueries(t *testing.T) {
+	ctx := context.Background()
+
+	withTestDB(t, func(db DBTX) {
+		querier := New()
+
+		var runner Runner
+
+		var (
+			testA Test
+			testB Test
+			testC Test
+		)
+
+		var (
+			runA Run
+			runB Run
+			runC Run
+		)
+
+		var (
+			runConfig    pgtype.JSONB
+			labels       pgtype.JSONB
+			matrix       pgtype.JSONB
+			testMatrixID uuid.UUID
+		)
+
+		err := runConfig.Set(&TestRunConfig{
+			ContainerImage: "image",
+			Command:        "cmd",
+			Args:           []string{"a"},
+			Env:            map[string]string{"env": "value"},
+			TimeoutSeconds: 60,
+		})
+		require.NoError(t, err)
+
+		err = labels.Set(map[string]string{"label": "value"})
+		require.NoError(t, err)
+
+		err = matrix.Set(&TestMatrix{
+			Labels: map[string][]string{"label": {"value_1", "value_2"}},
+		})
+		require.NoError(t, err)
+
+		testMatrixID = uuid.New()
+
+		testA, err = querier.RegisterTest(ctx, db, RegisterTestParams{
+			Namespace:    "ns1",
+			Name:         "testA",
+			RunConfig:    runConfig,
+			Labels:       labels,
+			Matrix:       matrix,
+			CronSchedule: sql.NullString{Valid: true, String: "* * * * *"},
+		})
+		require.NoError(t, err)
+
+		testB, err = querier.RegisterTest(ctx, db, RegisterTestParams{
+			Namespace:    "ns1",
+			Name:         "testB",
+			RunConfig:    runConfig,
+			Labels:       labels,
+			Matrix:       matrix,
+			CronSchedule: sql.NullString{Valid: true, String: "* * * * *"},
+		})
+		require.NoError(t, err)
+
+		testC, err = querier.RegisterTest(ctx, db, RegisterTestParams{
+			Namespace:    "ns2",
+			Name:         "testC",
+			RunConfig:    runConfig,
+			Labels:       labels,
+			Matrix:       matrix,
+			CronSchedule: sql.NullString{Valid: true, String: "* * * * *"},
+		})
+		require.NoError(t, err)
+
+		t.Run("ScheduleRun", func(t *testing.T) {
+			var err error
+			runA, err = querier.ScheduleRun(ctx, db, ScheduleRunParams{
+				Labels:       labels,
+				TestMatrixID: uuid.NullUUID{UUID: testMatrixID, Valid: true},
+				TestID:       testA.ID,
+				Namespace:    testA.Namespace,
+			})
+			require.NoError(t, err)
+			assert.NotZero(t, runA.ID)
+			assert.Equal(t, testA.ID, runA.TestID)
+			assert.Equal(t, testA.RunConfig, runA.TestRunConfig)
+			assert.Equal(t, testA.RunConfig, runA.TestRunConfig)
+			assert.NotZero(t, runA.TestMatrixID)
+			assert.Equal(t, testA.Labels, runA.Labels)
+			assert.Zero(t, runA.RunnerID.UUID)
+			assert.Equal(t, RunResultUnknown, runA.Result.RunResult)
+			assert.Equal(t, pgtype.JSONB{
+				Bytes:  nil,
+				Status: pgtype.Null,
+			}, runA.Logs)
+			assert.Equal(t, pgtype.JSONB{
+				Bytes:  []byte("{}"),
+				Status: pgtype.Present,
+			}, runA.ResultData)
+			assert.NotZero(t, runA.ScheduledAt)
+
+			runB, err = querier.ScheduleRun(ctx, db, ScheduleRunParams{
+				Labels:       labels,
+				TestMatrixID: uuid.NullUUID{UUID: testMatrixID, Valid: true},
+				TestID:       testB.ID,
+				Namespace:    testB.Namespace,
+			})
+			require.NoError(t, err)
+
+			runC, err = querier.ScheduleRun(ctx, db, ScheduleRunParams{
+				Labels:       labels,
+				TestMatrixID: uuid.NullUUID{UUID: testMatrixID, Valid: true},
+				TestID:       testC.ID,
+				Namespace:    testC.Namespace,
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("GetRun", func(t *testing.T) {
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testA.Namespace,
+				ID:        runA.ID,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, runA, run)
+		})
+
+		t.Run("ListRuns", func(t *testing.T) {
+			runs, err := querier.ListRuns(ctx, db, testA.Namespace)
+			require.NoError(t, err)
+			assert.Equal(t, []Run{runA, runB}, runs)
+		})
+
+		t.Run("ListPendingRuns", func(t *testing.T) {
+			runs, err := querier.ListPendingRuns(ctx, db)
+			require.NoError(t, err)
+			assert.Equal(t, []ListPendingRunsRow{
+				toListPendingRunsRow(runA, testA.Namespace),
+				toListPendingRunsRow(runB, testB.Namespace),
+				toListPendingRunsRow(runC, testC.Namespace),
+			}, runs)
+		})
+
+		t.Run("DeleteRunsForTest", func(t *testing.T) {
+			err := querier.DeleteRunsForTest(ctx, db, testC.ID)
+			require.NoError(t, err)
+
+			_, err = querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testC.Namespace,
+				ID:        runC.ID,
+			})
+			assert.ErrorIs(t, err, pgx.ErrNoRows)
+		})
+
+		t.Run("AssignRun", func(t *testing.T) {
+			var acceptSelectors pgtype.JSONB
+			err := acceptSelectors.Set(map[string]string{"label": ".*"})
+			require.NoError(t, err)
+
+			runner, err = querier.RegisterRunner(ctx, db, RegisterRunnerParams{
+				Name:                     "a",
+				NamespaceSelectors:       []string{"a"},
+				AcceptTestLabelSelectors: acceptSelectors,
+				RejectTestLabelSelectors: pgtype.JSONB{
+					Bytes:  nil,
+					Status: pgtype.Null,
+				},
+			})
+			require.NoError(t, err)
+
+			run, err := querier.AssignRun(ctx, db, AssignRunParams{
+				RunnerID: runner.ID,
+				RunIDs:   []uuid.UUID{runA.ID, runB.ID},
+			})
+			require.NoError(t, err)
+			runA.RunnerID = uuid.NullUUID{UUID: runner.ID, Valid: true}
+			assert.Equal(t, runA, run)
+
+			run, err = querier.AssignRun(ctx, db, AssignRunParams{
+				RunnerID: runner.ID,
+				RunIDs:   []uuid.UUID{runA.ID, runB.ID},
+			})
+			require.NoError(t, err)
+			runB.RunnerID = uuid.NullUUID{UUID: runner.ID, Valid: true}
+			assert.Equal(t, runB, run)
+		})
+
+		t.Run("UpdateRun", func(t *testing.T) {
+			start := time.Now().Truncate(time.Second)
+			finish := start.Add(time.Minute)
+
+			err := querier.UpdateRun(ctx, db, UpdateRunParams{
+				ID: runA.ID,
+				Result: NullRunResult{
+					RunResult: RunResultPass,
+					Valid:     true,
+				},
+				StartedAt:  sql.NullTime{Time: start, Valid: true},
+				FinishedAt: sql.NullTime{Time: finish, Valid: true},
+			})
+			require.NoError(t, err)
+
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testA.Namespace,
+				ID:        runA.ID,
+			})
+			require.NoError(t, err)
+			runA = run
+			assert.Equal(t, NullRunResult{RunResult: RunResultPass, Valid: true}, run.Result)
+			assert.Equal(t, sql.NullTime{Time: start, Valid: true}, run.StartedAt)
+			assert.Equal(t, sql.NullTime{Time: finish, Valid: true}, run.FinishedAt)
+		})
+
+		t.Run("AppendLogsToRun", func(t *testing.T) {
+			logs := []RunLog{{
+				Type: "tstr",
+				Time: time.Now().Format(time.RFC3339),
+				Data: []byte("log"),
+			}}
+			var runLogs pgtype.JSONB
+			err = runLogs.Set(logs)
+			require.NoError(t, err)
+
+			err := querier.AppendLogsToRun(ctx, db, AppendLogsToRunParams{
+				Logs: runLogs,
+				ID:   runA.ID,
+			})
+			require.NoError(t, err)
+
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testA.Namespace,
+				ID:        runA.ID,
+			})
+			require.NoError(t, err)
+			runA = run
+			var gotLogs []RunLog
+			err = run.Logs.AssignTo(&gotLogs)
+			require.NoError(t, err)
+			assert.Equal(t, logs, gotLogs)
+		})
+
+		t.Run("UpdateResultData", func(t *testing.T) {
+			data := map[string]string{"a": "123"}
+			var resultData pgtype.JSONB
+			err := resultData.Set(data)
+			require.NoError(t, err)
+
+			err = querier.UpdateResultData(ctx, db, UpdateResultDataParams{
+				ResultData: resultData,
+				ID:         runA.ID,
+			})
+			require.NoError(t, err)
+
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testA.Namespace,
+				ID:        runA.ID,
+			})
+			require.NoError(t, err)
+			runA = run
+			var gotData map[string]string
+			err = run.ResultData.AssignTo(&gotData)
+			require.NoError(t, err)
+			assert.Equal(t, data, gotData)
+		})
+
+		t.Run("ResetOrphanedRuns", func(t *testing.T) {
+			err := querier.ResetOrphanedRuns(ctx, db, time.Now().Add(time.Hour))
+			require.NoError(t, err)
+
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testB.Namespace,
+				ID:        runB.ID,
+			})
+			require.NoError(t, err)
+			assert.Zero(t, run.RunnerID.UUID)
+		})
+
+		t.Run("TimeoutRuns", func(t *testing.T) {
+			_, err := querier.AssignRun(ctx, db, AssignRunParams{
+				RunnerID: runner.ID,
+				RunIDs:   []uuid.UUID{runB.ID},
+			})
+			require.NoError(t, err)
+
+			err = querier.UpdateRun(ctx, db, UpdateRunParams{
+				ID: runB.ID,
+				Result: NullRunResult{
+					RunResult: RunResultUnknown,
+					Valid:     true,
+				},
+				StartedAt: sql.NullTime{Time: time.Now().Add(-time.Hour), Valid: true},
+			})
+			require.NoError(t, err)
+
+			logs := []RunLog{{
+				Type: "tstr",
+				Time: time.Now().Format(time.RFC3339),
+				Data: []byte("timeout"),
+			}}
+			var timeoutLogs pgtype.JSONB
+			err = timeoutLogs.Set(logs)
+			require.NoError(t, err)
+			err = querier.TimeoutRuns(ctx, db, TimeoutRunsParams{
+				TimeoutLog:     timeoutLogs,
+				DefaultTimeout: int32(time.Minute.Seconds()),
+			})
+			require.NoError(t, err)
+
+			run, err := querier.GetRun(ctx, db, GetRunParams{
+				Namespace: testB.Namespace,
+				ID:        runB.ID,
+			})
+			require.NoError(t, err)
+			runB = run
+			assert.Equal(t, NullRunResult{RunResult: RunResultError, Valid: true}, run.Result)
+			assert.NotZero(t, run.FinishedAt)
+			var gotLogs []RunLog
+			err = run.Logs.AssignTo(&gotLogs)
+			require.NoError(t, err)
+			assert.Equal(t, logs, gotLogs)
+		})
+
+		t.Run("RunSummariesForTest", func(t *testing.T) {
+			runs, err := querier.RunSummariesForTest(ctx, db, RunSummariesForTestParams{
+				Namespace:      testA.Namespace,
+				TestID:         testA.ID,
+				ScheduledAfter: sql.NullTime{Time: time.Now().Add(-time.Hour), Valid: true},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []RunSummariesForTestRow{toRunSummariesForTestRow(runA, testA)}, runs)
+		})
+
+		t.Run("RunSummariesForRunner", func(t *testing.T) {
+			runs, err := querier.RunSummariesForRunner(ctx, db, RunSummariesForRunnerParams{
+				Namespace:      testA.Namespace,
+				RunnerID:       uuid.NullUUID{UUID: runner.ID, Valid: true},
+				ScheduledAfter: sql.NullTime{Time: time.Now().Add(-time.Hour), Valid: true},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []RunSummariesForRunnerRow{
+				toRunSummariesForRunnerRow(runA, testA),
+				toRunSummariesForRunnerRow(runB, testB),
+			}, runs)
+		})
+
+		t.Run("QueryRuns", func(t *testing.T) {
+			t.Skipf("TODO: need to implement")
+		})
+
+		t.Run("SummarizeRunsBreakdownResult", func(t *testing.T) {
+			t.Skipf("TODO: need to implement")
+		})
+
+		t.Run("SummarizeRunsBreakdownTest", func(t *testing.T) {
+			t.Skipf("TODO: need to implement")
+		})
+	})
+}
+
+func toListPendingRunsRow(r Run, ns string) ListPendingRunsRow {
+	return ListPendingRunsRow{
+		ID:            r.ID,
+		TestID:        r.TestID,
+		TestRunConfig: r.TestRunConfig,
+		TestMatrixID:  r.TestMatrixID,
+		Labels:        r.Labels,
+		RunnerID:      r.RunnerID,
+		Result:        r.Result,
+		Logs:          r.Logs,
+		ResultData:    r.ResultData,
+		ScheduledAt:   r.ScheduledAt,
+		StartedAt:     r.StartedAt,
+		FinishedAt:    r.FinishedAt,
+		Namespace:     ns,
+	}
+}
+
+func toRunSummariesForTestRow(r Run, t Test) RunSummariesForTestRow {
+	return RunSummariesForTestRow{
+		ID:            r.ID,
+		TestNamespace: t.Namespace,
+		TestID:        t.ID,
+		TestName:      t.Name,
+		TestRunConfig: t.RunConfig,
+		Labels:        t.Labels,
+		RunnerID:      r.RunnerID,
+		Result:        r.Result,
+		ScheduledAt:   r.ScheduledAt,
+		StartedAt:     r.StartedAt,
+		FinishedAt:    r.FinishedAt,
+		ResultData:    r.ResultData,
+	}
+}
+
+func toRunSummariesForRunnerRow(r Run, t Test) RunSummariesForRunnerRow {
+	return RunSummariesForRunnerRow{
+		ID:            r.ID,
+		TestNamespace: t.Namespace,
+		TestID:        t.ID,
+		TestName:      t.Name,
+		TestRunConfig: t.RunConfig,
+		Labels:        t.Labels,
+		RunnerID:      r.RunnerID,
+		Result:        r.Result,
+		ScheduledAt:   r.ScheduledAt,
+		StartedAt:     r.StartedAt,
+		FinishedAt:    r.FinishedAt,
+		ResultData:    r.ResultData,
+	}
+}


### PR DESCRIPTION
This adds tests for the simpler runs queries. The remaining ones require more state setup for testing.

I'm not the biggest fan of the current style of testing for the db queries. Trying to put together a test suite that's order and state dependent is not ideal and doesn't really handle edge cases well, but this is also the easiest way and lowest amount of boilerplate way to get some initial tests in. I would like to revisit this entirely another time.