### PR TITLE
Added missing test namespace in the scheduler update test execution

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -137,6 +137,7 @@ func (s *Scheduler) Start() error {
 						RunConfig:    test.RunConfig,
 						CronSchedule: test.CronSchedule,
 						NextRunAt:    sql.NullTime{Valid: true, Time: nextRunAt},
+						Namespace:    test.Namespace,
 					})
 					if err != nil {
 						log.Error().


### PR DESCRIPTION
Due to missing test namespace, the test update failed to execute and the nextRunAt haven't been updated from the initial value